### PR TITLE
Goals are no longer rendered

### DIFF
--- a/Runtime/Resources/Prefabs/MaktubCollisionGoal.prefab
+++ b/Runtime/Resources/Prefabs/MaktubCollisionGoal.prefab
@@ -14,7 +14,7 @@ GameObject:
   - component: {fileID: 6449037860857586398}
   - component: {fileID: 6449037860857586386}
   - component: {fileID: 6449037860857586399}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: MaktubCollisionGoal
   m_TagString: Goal
   m_Icon: {fileID: 0}


### PR DESCRIPTION
In order for this to take effect in dependent projects, the Camera culling mask must include "editorOnly".